### PR TITLE
Used duck typing to determine whether or not 'r.json' is called

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
-# from distutils.core import setup
-#
-# setup(
-#     name='zinc',
-#     version='0.1.1',
-#     author='Eric Swanson',
-#     author_email='eswanson@alloscomp.com',
-#     packages=['zinc'],
-#     url='http://pypi.python.org/pypi/Zinc/',
-#     license='LICENSE.txt',
-#     description='Wrapper for Zinc ecommerce API (zinc.io).',
-#     long_description=open('README.md').read(),
-#     install_requires=[
-#     ],
-# )
+from distutils.core import setup
+
+setup(
+    name='zinc',
+    version='0.1.1',
+    author='Eric Swanson',
+    author_email='eswanson@alloscomp.com',
+    packages=['zinc'],
+    url='http://pypi.python.org/pypi/Zinc/',
+    license='LICENSE.txt',
+    description='Wrapper for Zinc ecommerce API (zinc.io).',
+    long_description=open('README.md').read(),
+    install_requires=[
+    ],
+)


### PR DESCRIPTION
This was throwing an error with the latest version of the requests package and python 2.7
